### PR TITLE
feat: added route bulk

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -17,16 +17,35 @@ server.get("/api/setAccountType/:apitoken/:token/:type", require("./routes/api/s
 server.get("/api/updateUserModels/:apitoken/:name/:cape/:elytra/:ears", require("./routes/api/updateUserModels").readRequest)
 server.post("/api/setGuildColor/:apitoken", require("./routes/api/setGuildColor").readRequest)
 
-server.get("/cache/getItemList", require("./routes/cache/getItemList").readRequest)
-server.get("/cache/getMapLocations", require("./routes/cache/getMapLocations").readRequest)
-server.get("/cache/getTerritoryList", require("./routes/cache/getTerritoryList").readRequest)
-
-server.get("/getUserModels", require("./routes/getUserModelsRoute").readRequest)
-server.get("/getUsersRoles", require("./routes/getUsersRolesRoute").readRequest)
 server.get("/requestEncryption", require("./routes/requestEncryption").readRequest)
 server.post("/responseEncryption", require("./routes/responseEncryption").readRequest)
 server.post("/uploadConfig/:token", require("./routes/uploadConfig").readRequest)
 server.post("/updateDiscord/:token", require("./routes/updateDiscord").readRequest)
+
+var bulkRoutes = {
+    itemList: {
+        route: "/cache/getItemList",
+        module: require("./routes/cache/getItemList")
+    },
+    mapLocations: {
+        route: "/cache/getMapLocations",
+        module: require("./routes/cache/getMapLocations")
+    },
+    territoryList: {
+        route: "/cache/getTerritoryList",
+        module: require("./routes/cache/getTerritoryList")
+    },
+    userModels: {
+        route: "/getUserModels",
+        module: require("./routes/getUserModelsRoute")
+    },
+    userRoles: {
+        route: "/getUsersRoles",
+        module: require("./routes/getUsersRolesRoute")
+    }
+}
+
+require("./routes/bulk")(server, bulkRoutes)
 
 server.use((req, res) => {res.status(200).redirect(config.redirectUrl)})
 

--- a/src/routes/bulk.js
+++ b/src/routes/bulk.js
@@ -1,0 +1,45 @@
+module.exports = (server, bulkRoutes) => {
+    for (const key in bulkRoutes) {
+        if (bulkRoutes.hasOwnProperty(key)) {
+            server.get(bulkRoutes[key].route, bulkRoutes[key].module.readRequest)
+        }
+    }
+
+    server.get("/bulk", (req, res) => {
+        const query = req.originalUrl.match(/\?(.*)(?:#|$)/)
+        if (query == null) {
+            res.status(400).send({
+                result: "Bad request: Missing query string",
+                request: req.requestJson
+            })
+            return
+        }
+        const responseKeys = new Set()
+        const unknownKeys = []
+        for (const q of query[1].split("&")) {
+            if (bulkRoutes.hasOwnProperty(q)) {
+                responseKeys.add(q)
+            } else if (q) {  // Ignore empty string
+                unknownKeys.push(q)
+            }
+        }
+        if (unknownKeys.length > 0) {
+            res.status(404).send({
+                result: "Not found: Unknown keys [\"" + unknownKeys.join("\", \"") + "\"]",
+                request: req.requestJson
+            })
+            return
+        }
+
+        const responseData = {}
+        for (const key of responseKeys) {
+            responseData[key] = bulkRoutes[key].module.createResponse()
+        }
+
+        res.status(200).send({
+            result: "Success",
+            data: responseData,
+            request: req.requestJson
+        })
+    })
+}

--- a/src/routes/cache/getItemList.js
+++ b/src/routes/cache/getItemList.js
@@ -4,4 +4,5 @@ function readRequest(req, res) {
     res.status(200).send(wynnData.cachedItems)
 }
 
+module.exports.createResponse = () => wynnData.cachedItems
 module.exports.readRequest = readRequest

--- a/src/routes/cache/getMapLocations.js
+++ b/src/routes/cache/getMapLocations.js
@@ -4,4 +4,5 @@ function readRequest(req, res) {
     res.status(200).send(wynnData.mapLocations)
 }
 
+module.exports.createResponse = () => wynnData.mapLocations
 module.exports.readRequest = readRequest

--- a/src/routes/cache/getTerritoryList.js
+++ b/src/routes/cache/getTerritoryList.js
@@ -4,4 +4,5 @@ function readRequest(req, res) {
     res.status(200).send(wynnData.getTerritoryCache())
 }
 
+module.exports.createResponse = () => wynnData.getTerritoryCache()
 module.exports.readRequest = readRequest

--- a/src/routes/getUserModelsRoute.js
+++ b/src/routes/getUserModelsRoute.js
@@ -1,8 +1,6 @@
 const userManager = require("../core/managers/userManager")
 
-function readRequest(req, res) {
-    var json = new Object()
-
+function createResponse() {
     var capes = []
     var elytra = []
     var ears = []
@@ -13,13 +11,20 @@ function readRequest(req, res) {
         if(c.getActiveModels().earsActive) ears.push(c.getId())
     })
 
-    json.capeActive = capes
-    json.elytraActive = elytra
-    json.earsActive = ears
+    return {
+        capeActive: capes,
+        elytraActive: elytra,
+        earsActive: ears
+    }
+}
+
+function readRequest(req, res) {
+    var json = createResponse()
 
     json.request = req.requestJson
 
     res.status(200).send(json)
 }
 
+module.exports.createResponse = createResponse
 module.exports.readRequest = readRequest

--- a/src/routes/getUsersRolesRoute.js
+++ b/src/routes/getUsersRolesRoute.js
@@ -1,30 +1,35 @@
 const userManager = require("../core/managers/userManager")
 const up = require("../core/profiles/userProfile")
 
-function readRequest(req, res) {
-    var json = new Object()
-
+function createResponse() {
     var helpers = []
     var moderators = []
     var donators = []
-    var content_team = []
+    var contentTeam = []
 
     userManager.userProfiles.forEach(c => {
         if(c.getAccountType() === up.AccountType.HELPER) helpers.push(c.getId())
-        else if(c.getAccountType() == up.AccountType.CONTENT_TEAM) content_team.push(c.getId())
+        else if(c.getAccountType() === up.AccountType.CONTENT_TEAM) contentTeam.push(c.getId())
         else if(c.getAccountType() === up.AccountType.MODERATOR) moderators.push(c.getId())
         else if(c.getAccountType() === up.AccountType.DONATOR) donators.push(c.getId())
     })
 
-    json.normalUsers = []
-    json.donatorUsers = donators
-    json.contentTeamUsers = content_team
-    json.helperUsers = helpers
-    json.moderatorUsers = moderators
+    return {
+        normalUsers: [],
+        donatorUsers: donators,
+        contentTeamUsers: contentTeam,
+        moderatorUsers: moderators,
+        helperUsers: helpers
+    }
+}
+
+function readRequest(req, res) {
+    var json = createResponse()
 
     json.request = req.requestJson
 
     res.status(200).send(json)
 }
 
+module.exports.createResponse = createResponse
 module.exports.readRequest = readRequest


### PR DESCRIPTION
To send multiple requests at once.

E.g. `GET /bulk?itemList&userModels` will return:

```js
{
    "result": "Success",
    "data": {
        "itemList": /* itemList */,
        "userModels": {
            "capeActive": /* capes */,
            "elytraActive": /* elytras */,
            "earsActive": /* ears */
        }
    },
    "request": {
        "ipAddress": /* ip */,
        "timestamp": /* time */
    }
}
```

Collapsing two `GET` requests into one.

(I'll also patch the mod to use this if possible)